### PR TITLE
Fix systemd_config_dir send_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Disable timeout for image build/pull.
 - Add `configured` state to pod/container service.
+- Set `send_event=true` for systemd_service files.
 
 ## v0.2.0 - 2024-03-17
 

--- a/model/services/systemd_service.cf
+++ b/model/services/systemd_service.cf
@@ -47,6 +47,8 @@ implementation service_configuration for SystemdService:
         owner=user,
         group=user,
         host=host,
+        send_event=true,
+        reload=true,
         # requires=self.requires,  # We don't need this directory to be created after our requires
         provides=self.provides,  # But we need to make sure it is created before our provides
     )


### PR DESCRIPTION
# Description

Fix `send_event=true` for systemd servies

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
