### PR TITLE
Fix service enabling, using full path as symlink target

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install inmanta-core
@@ -18,7 +18,7 @@ jobs:
     - name: Build a binary wheel
       run: python3 -m inmanta.app module build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -59,12 +59,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: >-
           ./dist/*.tar.gz
@@ -95,7 +95,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install inmanta-core
@@ -103,7 +103,7 @@ jobs:
     - name: Build a binary wheel
       run: python3 -m inmanta.app module build --dev
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions-dev
         path: dist/
@@ -124,7 +124,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions-dev
         path: dist/

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           architecture: 'x64'
@@ -35,7 +35,7 @@ jobs:
       options: --privileged
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install python3.11, gcc and git
         run: |
           yum install -y python3.11 python3.11-devel gcc git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.7.0 - ?
 
+- Fix service enabling, using full path as symlink target
 - Allow to provide any arg, for any command used to manage pod/containers, on the ContainerLike entity
 
 ## v0.6.0 - 2024-05-28

--- a/model/services/systemd_service.cf
+++ b/model/services/systemd_service.cf
@@ -264,7 +264,6 @@ implementation service_activation for SystemdService:
         target=f"{self._systemd_config_dir.path}{unit_name}",
         path=f"{self._systemd_config_dir.path}default.target.wants/{unit_name}",
         host=host,
-        permissions=777,
         owner=user,
         group=user,
         purged=self.state == "removed" or not self.enabled,

--- a/model/services/systemd_service.cf
+++ b/model/services/systemd_service.cf
@@ -261,7 +261,7 @@ implementation service_activation for SystemdService:
     unit_name = self.on_calendar is defined ? self.timer_name : self.service_name
 
     symlink = std::Symlink(
-        source=f"../{unit_name}",
+        source=f"{self._systemd_config_dir.path}{unit_name}",
         target=f"{self._systemd_config_dir.path}default.target.wants/{unit_name}",
         send_event=true,
         reload=true,

--- a/model/services/systemd_service.cf
+++ b/model/services/systemd_service.cf
@@ -261,7 +261,7 @@ implementation service_activation for SystemdService:
     unit_name = self.on_calendar is defined ? self.timer_name : self.service_name
 
     symlink = files::Symlink(
-        parget=f"{self._systemd_config_dir.path}{unit_name}",
+        target=f"{self._systemd_config_dir.path}{unit_name}",
         path=f"{self._systemd_config_dir.path}default.target.wants/{unit_name}",
         host=host,
         permissions=777,

--- a/model/services/systemd_service.cf
+++ b/model/services/systemd_service.cf
@@ -260,12 +260,13 @@ implementation service_activation for SystemdService:
     # to the service, not the service itself
     unit_name = self.on_calendar is defined ? self.timer_name : self.service_name
 
-    symlink = std::Symlink(
-        source=f"{self._systemd_config_dir.path}{unit_name}",
-        target=f"{self._systemd_config_dir.path}default.target.wants/{unit_name}",
-        send_event=true,
-        reload=true,
+    symlink = files::Symlink(
+        parget=f"{self._systemd_config_dir.path}{unit_name}",
+        path=f"{self._systemd_config_dir.path}default.target.wants/{unit_name}",
         host=host,
+        permissions=777,
+        owner=user,
+        group=user,
         purged=self.state == "removed" or not self.enabled,
         requires=self.requires,
         provides=self.provides,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 inmanta-module-exec==1.1.22
 inmanta-module-std==5.2.2
-inmanta-module-files==0.5.0
+inmanta-module-files==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 inmanta-module-exec==1.1.22
 inmanta-module-std==5.2.2
-inmanta-module-files==0.4.0
+inmanta-module-files==0.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ packages=find_namespace:
 install_requires =
     inmanta-module-std>=4.0,<6
     inmanta-module-exec>=1.1,<2
-    inmanta-module-files>=0.4.0.dev0,<1
+    inmanta-module-files>=0.5.0.dev0,<1
 
 [options.packages.find]
 include = inmanta_plugins*

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ packages=find_namespace:
 install_requires =
     inmanta-module-std>=4.0,<6
     inmanta-module-exec>=1.1,<2
-    inmanta-module-files>=0.5.0.dev0,<1
+    inmanta-module-files>=0.5.0,<1
 
 [options.packages.find]
 include = inmanta_plugins*


### PR DESCRIPTION
# Description

- Create service enabling symlinks using full path (the same way systemd would)

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
