### PR TITLE
Issue/podman user wait network online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.4.1 - ?
 
+- Make sure container and pod units wait on podman-user-wait-network-online.service when running rootless.
 
 ## v1.4.0 - 2025-04-11
 

--- a/model/services/systemd_container.cf
+++ b/model/services/systemd_container.cf
@@ -68,7 +68,7 @@ implementation unit_file for SystemdContainer:
             description=self.description is defined ? self.description : f"Podman {self.service_name}",
             documentation=["https://github.com/edvgui/inmanta-module-podman"],
             wants=[
-                "network-online.target",
+                user == "root" ? "network-online.target" : "podman-user-wait-network-online.service",
                 self.on_calendar is defined ? [self.timer_name] : [],
                 self.listen_stream is defined ? [self.socket_name] : [],
             ],
@@ -78,7 +78,7 @@ implementation unit_file for SystemdContainer:
                 : [],
             after=[
                 pod_service is defined ? [pod_service.service_name] : [],
-                "network-online.service",
+                user == "root" ? "network-online.target" : "podman-user-wait-network-online.service",
             ],
             part_of=[
                 self.on_calendar is defined ? [self.timer_name] : [],


### PR DESCRIPTION
# Description

Make sure that rootless services wait for the network to be online

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
