### PR TITLE
Add missing on_failure option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.8.1 - ?
 
+- Add missing wiring of on_failure option
 
 ## v1.8.0 - 2025-08-17
 

--- a/model/services/systemd_container.cf
+++ b/model/services/systemd_container.cf
@@ -176,6 +176,7 @@ implementation quadlet_file for SystemdContainer:
                 self.on_calendar is defined ? [self.timer_name] : [],
                 self.listen_stream is defined ? [self.socket_name] : [],
             ],
+            on_failure=self.on_failure,
         ),
         install=Install(
             wanted_by=["default.target"],

--- a/model/services/systemd_service.cf
+++ b/model/services/systemd_service.cf
@@ -209,6 +209,7 @@ implementation service_socket for SystemdService:
                 description=self.description is defined ? self.description : f"Podman {self.socket_name}",
                 documentation=["https://github.com/edvgui/inmanta-module-podman"],
                 requires=[self.service_name],
+                on_failure=self.on_failure,
             ),
             socket=Socket(
                 listen_stream=self.listen_stream,


### PR DESCRIPTION
# Description

- Add missing wiring of on_failure option

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
