### PR TITLE
Add dependencies between container services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v1.11.4 - ?
+## v1.12.0 - ?
+
+- Allow expressing dependencies between container services (`Requires=`/`After=`)
 
 
 ## v1.11.3 - 2026-06-28

--- a/model/services/_init.cf
+++ b/model/services/_init.cf
@@ -123,6 +123,20 @@ entity SystemdContainer extends SystemdService:
 end
 SystemdContainer.container [1] -- podman::Container
 
+SystemdContainer.dependencies [0:] -- SystemdService.dependents [0:]
+"""
+Other systemd services that this container requires to be running in order to
+work properly.  Each dependency is translated into a ``Requires=`` and an
+``After=`` entry in the container unit file, so that the dependencies are
+started before this container, and this container is stopped (before any of its
+dependencies) whenever one of them is stopped.
+
+This works both for long-running containers (e.g. an application depending on a
+database) and for calendar-triggered containers (e.g. a database dump depending
+on the database): in the latter case the dependencies are pulled in when the
+timer activates the service.
+"""
+
 
 entity SystemdAutoUpdate extends SystemdService:
     """

--- a/model/services/systemd_container.cf
+++ b/model/services/systemd_container.cf
@@ -56,6 +56,10 @@ implementation unit_file for SystemdContainer:
     # Set the variable that is required by the container.service.j2 template
     container = self.container
 
+    # Services that this container requires to be running, translated into
+    # Requires= and After= entries in the unit file.
+    dependency_services = [dependency.service_name for dependency in self.dependencies]
+
     # Create the service unit for the pod
     self.unit = files::SystemdUnitFile(
         path=files::path_join(self._systemd_config_dir.path, self.service_name),
@@ -73,12 +77,14 @@ implementation unit_file for SystemdContainer:
                 self.listen_stream is defined ? [self.socket_name] : [],
             ],
             requires_mounts_for=["%t/containers"],
+            requires=dependency_services,
             binds_to=pod_service is defined
                 ? [pod_service.service_name]
                 : [],
             after=[
                 pod_service is defined ? [pod_service.service_name] : [],
                 user == "root" ? "network-online.target" : "podman-user-wait-network-online.service",
+                dependency_services,
             ],
             part_of=[
                 self.on_calendar is defined ? [self.timer_name] : [],
@@ -147,6 +153,10 @@ implementation quadlet_file for SystemdContainer:
         ? pod._systemd_service
         : null
 
+    # Services that this container requires to be running, translated into
+    # Requires= and After= entries in the unit file.
+    dependency_services = [dependency.service_name for dependency in self.dependencies]
+
     std::assert(self.systemd_container_dir != null, "The attribute systemd_container_dir must be set when quadlet is true.")
     std::assert(self._container_config_dir is defined, "Compiler error, self._container_config_dir must be set.")
     self.unit = QuadletUnitFile(
@@ -166,11 +176,13 @@ implementation quadlet_file for SystemdContainer:
                 self.on_calendar is defined ? [self.timer_name] : [],
                 self.listen_stream is defined ? [self.socket_name] : [],
             ],
+            requires=dependency_services,
             binds_to=pod_service is defined
                 ? [pod_service.service_name]
                 : [],
             after=[
                 pod_service is defined ? [pod_service.service_name] : [],
+                dependency_services,
             ],
             part_of=[
                 self.on_calendar is defined ? [self.timer_name] : [],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inmanta-module-podman
-version = 1.11.4
+version = 1.12.0
 description = Simple module to manage podman resources
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_container_dependencies.py
+++ b/tests/test_container_dependencies.py
@@ -1,0 +1,259 @@
+"""
+Copyright 2026 Guillaume Everarts de Velp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: edvgui@gmail.com
+"""
+
+import pathlib
+
+from pytest_inmanta.plugin import Project, Result
+
+
+def build_model(
+    *,
+    quadlet: bool = False,
+    on_calendar: str | None = None,
+    state: str = "stopped",
+) -> str:
+    """
+    Build a model where an ``app`` container depends on a ``db`` container.
+
+    :param quadlet: Whether the services should be generated as quadlet units.
+    :param on_calendar: When set, the dependent service is calendar-triggered
+        (like a periodic database dump) instead of being long-running.
+    :param state: The desired state for the services.
+    """
+    container_dir = (
+        'systemd_container_dir="/tmp/containers/systemd",' if quadlet else ""
+    )
+    on_calendar_option = (
+        f"on_calendar={on_calendar!r}," if on_calendar is not None else ""
+    )
+    return f"""
+        import podman
+        import podman::services
+        import mitogen
+        import std
+
+        host = std::Host(
+            name="localhost",
+            remote_agent=true,
+            ip="127.0.0.1",
+            os=std::linux,
+            via=mitogen::Local(),
+        )
+
+        db = podman::Container(
+            host=host,
+            name="postgresql-server",
+            image="docker.io/library/postgres:13",
+        )
+
+        app = podman::Container(
+            host=host,
+            name="my-app",
+            image="docker.io/library/nginx:latest",
+        )
+
+        db_service = podman::services::SystemdContainer(
+            container=db,
+            state={state!r},
+            systemd_unit_dir="/tmp/systemd/user",
+            {container_dir}
+            systemctl_command=["systemctl", "--user"],
+            quadlet={"true" if quadlet else "false"},
+        )
+
+        podman::services::SystemdContainer(
+            container=app,
+            state={state!r},
+            {on_calendar_option}
+            systemd_unit_dir="/tmp/systemd/user",
+            {container_dir}
+            systemctl_command=["systemctl", "--user"],
+            quadlet={"true" if quadlet else "false"},
+            dependencies=[db_service],
+        )
+    """
+
+
+def _dependent_unit_content(project: Project, *, quadlet: bool) -> str:
+    """
+    Return the content of the generated unit file for the ``app`` container.
+    """
+    if quadlet:
+        path = pathlib.Path("/tmp/containers/systemd") / "container-my-app.container"
+    else:
+        path = pathlib.Path("/tmp/systemd/user") / "container-my-app.service"
+
+    unit_file_resource = next(
+        r for r in project.resources.values() if getattr(r, "path", None) == str(path)
+    )
+    return unit_file_resource.content
+
+
+def test_dependency_in_service_unit(project: Project) -> None:
+    """
+    A long-running container that depends on another one must reference it with
+    both a ``Requires=`` and an ``After=`` directive in its unit file.
+    """
+    project.compile(build_model(), no_dedent=False)
+
+    content = _dependent_unit_content(project, quadlet=False)
+    assert "Requires=container-postgresql-server.service" in content
+    assert "After=container-postgresql-server.service" in content
+
+
+def test_dependency_in_quadlet_unit(project: Project) -> None:
+    """
+    Same as above, but for a container managed through a quadlet unit file.
+    """
+    project.compile(build_model(quadlet=True), no_dedent=False)
+
+    content = _dependent_unit_content(project, quadlet=True)
+    assert "Requires=container-postgresql-server.service" in content
+    assert "After=container-postgresql-server.service" in content
+
+
+def test_dependency_on_calendar_service(project: Project) -> None:
+    """
+    A calendar-triggered container (e.g. a periodic database dump) that depends
+    on another container must still pull in its dependency via ``Requires=`` and
+    ``After=`` so the dependency is running when the timer activates the service.
+    """
+    project.compile(build_model(on_calendar="daily"), no_dedent=False)
+
+    content = _dependent_unit_content(project, quadlet=False)
+    assert "Requires=container-postgresql-server.service" in content
+    assert "After=container-postgresql-server.service" in content
+
+
+def test_no_dependency_no_directive(project: Project) -> None:
+    """
+    A container without dependencies must not gain a ``Requires=`` directive
+    pointing at another container.
+    """
+    project.compile(
+        """
+        import podman
+        import podman::services
+        import mitogen
+        import std
+
+        host = std::Host(
+            name="localhost",
+            remote_agent=true,
+            ip="127.0.0.1",
+            os=std::linux,
+            via=mitogen::Local(),
+        )
+
+        app = podman::Container(
+            host=host,
+            name="my-app",
+            image="docker.io/library/nginx:latest",
+        )
+
+        podman::services::SystemdContainer(
+            container=app,
+            state="stopped",
+            systemd_unit_dir="/tmp/systemd/user",
+            systemctl_command=["systemctl", "--user"],
+        )
+        """,
+        no_dedent=False,
+    )
+
+    content = _dependent_unit_content(project, quadlet=False)
+    assert "Requires=container-" not in content
+
+
+def test_multiple_dependencies(project: Project) -> None:
+    """
+    A container can depend on several other services at once.
+    """
+    project.compile(
+        """
+        import podman
+        import podman::services
+        import mitogen
+        import std
+
+        host = std::Host(
+            name="localhost",
+            remote_agent=true,
+            ip="127.0.0.1",
+            os=std::linux,
+            via=mitogen::Local(),
+        )
+
+        db = podman::Container(host=host, name="database", image="postgres:13")
+        cache = podman::Container(host=host, name="cache", image="redis:7")
+        app = podman::Container(host=host, name="my-app", image="nginx:latest")
+
+        db_service = podman::services::SystemdContainer(
+            container=db,
+            state="stopped",
+            systemd_unit_dir="/tmp/systemd/user",
+            systemctl_command=["systemctl", "--user"],
+        )
+        cache_service = podman::services::SystemdContainer(
+            container=cache,
+            state="stopped",
+            systemd_unit_dir="/tmp/systemd/user",
+            systemctl_command=["systemctl", "--user"],
+        )
+
+        podman::services::SystemdContainer(
+            container=app,
+            state="stopped",
+            systemd_unit_dir="/tmp/systemd/user",
+            systemctl_command=["systemctl", "--user"],
+            dependencies=[db_service, cache_service],
+        )
+        """,
+        no_dedent=False,
+    )
+
+    content = _dependent_unit_content(project, quadlet=False)
+    assert "Requires=container-database.service" in content
+    assert "After=container-database.service" in content
+    assert "Requires=container-cache.service" in content
+    assert "After=container-cache.service" in content
+
+
+def test_deploy_with_dependencies(project: Project) -> None:
+    """
+    Make sure a model using container dependencies can be deployed and reaches
+    a stable state, across the supported service states.
+    """
+    for state in ["configured", "stopped", "removed"]:
+        project.compile(build_model(state=state), no_dedent=False)
+
+        project.deploy_all(
+            exclude_all=[
+                "std::AgentConfig",
+                "exec::Run",
+            ],
+        ).assert_all()
+
+        dry_run_result = Result(
+            {
+                r: project.dryrun(r, run_as_root=False)
+                for r in project.resources.values()
+                if (not r.is_type("std::AgentConfig") and not r.is_type("exec::Run"))
+            }
+        )
+        dry_run_result.assert_has_no_changes()


### PR DESCRIPTION
## Summary

Adds the ability to express dependencies between container services within their unit files.

A `podman::services::SystemdContainer` can now declare a list of other systemd services it depends on via a new `dependencies` relation. Each dependency is rendered as a `Requires=` and an `After=` entry in the container's unit file, so that:

- dependencies are started **before** the dependent container;
- the dependent container is stopped **before** (and whenever) any of its dependencies is stopped, or if a dependency fails to start.

This works both for:
- **long-running containers** — e.g. an application depending on a database, and
- **calendar-triggered containers** — e.g. a periodic database dump depending on the database (the dependency is pulled in when the timer activates the service).

Both plain systemd units and quadlet units are supported.

## Usage

```
db_service = podman::services::SystemdContainer(container=db, ...)

podman::services::SystemdContainer(
    container=app,
    dependencies=[db_service],   # -> Requires=/After=container-postgresql-server.service
    ...
)
```

## Design notes

- The `dependencies` relation lives on `SystemdContainer` (the dependent is always a container, matching the use cases) and targets `SystemdService`, so a container can also depend on a pod service.
- The directive used is `Requires=` (lenient toward transient crashes of the dependency), paired with `After=` for ordering.

## Testing

New `tests/test_container_dependencies.py` covering: plain service unit, quadlet unit, calendar-triggered service, the no-dependency negative case, multiple dependencies, and a deploy/idempotency check across service states. Full suite passes (28 tests), `black` + `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)