### PR TITLE
Add configurable pull_timeout to podman::ImageFromRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v1.12.1 - ?
+## v1.13.0 - ?
+
+- Add a configurable `pull_timeout` to `podman::ImageFromRegistry` (defaults to null, i.e. no timeout)
 
 
 ## v1.12.0 - 2026-07-11

--- a/inmanta_plugins/podman/resources/image.py
+++ b/inmanta_plugins/podman/resources/image.py
@@ -248,9 +248,10 @@ class ImageFromSourceHandler(ImageHandler[ImageFromSourceResource]):
     agent="host.name",
 )
 class ImageFromRegistryResource(ImageResource):
-    fields = ("transport", "digest")
+    fields = ("transport", "digest", "pull_timeout")
     transport: str | None
     digest: str | None
+    pull_timeout: int | None
 
 
 @inmanta.agent.handler.provider("podman::ImageFromRegistry", "")
@@ -288,7 +289,7 @@ class ImageFromRegistryHandler(ImageHandler[ImageFromRegistryResource]):
             ctx,
             resource,
             command=["podman", "image", "pull", source],
-            timeout=None,
+            timeout=resource.pull_timeout,
         )
 
         # If the command failed, something went wrong

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -334,9 +334,13 @@ end
 entity ImageFromRegistry extends Image:
     """
     Pull an image from a registry
+
+    :attr pull_timeout: The maximum duration, in seconds, that the pull command
+        is allowed to take before it is aborted.  When null, no timeout is applied.
     """
     string? transport = null
     string? digest = null
+    int? pull_timeout = null
 end
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inmanta-module-podman
-version = 1.12.1
+version = 1.13.0
 description = Simple module to manage podman resources
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_image_from_registry.py
+++ b/tests/test_image_from_registry.py
@@ -20,6 +20,8 @@ import json
 
 from pytest_inmanta.plugin import Project
 
+import inmanta.const
+
 
 def test_model(
     project: Project, purged: bool = False, digest: str | None = None
@@ -53,6 +55,49 @@ def test_model(
     """
 
     project.compile(model, no_dedent=False)
+
+
+def test_pull_timeout(project: Project) -> None:
+    # Pull an image from a registry that can not be reached, with a very
+    # short timeout.  The pull command hangs trying to connect, so the
+    # timeout aborts it and the deployment must fail explicitly.
+    model = """
+        import podman
+        import std
+        import mitogen
+
+
+        host = std::Host(
+            name="localhost",
+            remote_agent=true,
+            ip="127.0.0.1",
+            os=std::linux,
+            via=mitogen::Local(),
+        )
+
+        podman::ImageFromRegistry(
+            host=host,
+            # RFC 5737 TEST-NET-1 address, guaranteed not to be routable, so the
+            # pull hangs on connection until our timeout kicks in.
+            name="192.0.2.1:5000/inmanta/does-not-exist:latest",
+            pull_timeout=1,
+        )
+    """
+
+    project.compile(model, no_dedent=False)
+
+    resource = project.get_resource("podman::ImageFromRegistry")
+    assert resource is not None
+    assert resource.pull_timeout == 1
+
+    result = project.deploy_resource_v2(
+        "podman::ImageFromRegistry",
+        expected_status=inmanta.const.ResourceState.failed,
+    )
+
+    # The failure must clearly point at the pull command timing out after the
+    # configured duration.
+    result.assert_has_logline(r"podman.*pull.*timed out after 1 seconds")
 
 
 def test_deploy(project: Project) -> None:


### PR DESCRIPTION
## Summary

The `podman::ImageFromRegistry` pull command previously ran with **no timeout**, so a stalled registry pull could hang a deployment indefinitely.

This PR adds a configurable `pull_timeout` attribute, set from the model, that bounds the duration of the `podman image pull` command.

## Changes

- **`model/_init.cf`**: add `int? pull_timeout = null` to the `ImageFromRegistry` entity (with docstring).
- **`inmanta_plugins/podman/resources/image.py`**: expose `pull_timeout` as a resource field and pass it through to `run_command` in `pull_image`.
- **`tests/test_image_from_registry.py`**: add `test_pull_timeout`, a behavioral test that pulls from a non-routable registry (RFC 5737 TEST-NET-1) with `pull_timeout=1`, asserts the deployment ends in `failed`, and asserts the failure log explicitly reports the pull command timing out after the configured duration.

## Behaviour

Defaults to `null` (no timeout), preserving the previous behaviour. Set `pull_timeout` on the entity to bound the pull, e.g. `pull_timeout=60` for 60 seconds. On expiry the deployment fails with an explicit `... podman image pull ... timed out after N seconds` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)