### PR TITLE
Add build_timeout to ImageFromSource and bound the whoami command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v1.13.0 - ?
 
 - Add a configurable `pull_timeout` to `podman::ImageFromRegistry` (defaults to null, i.e. no timeout)
+- Add a configurable `build_timeout` to `podman::ImageFromSource` (defaults to null, i.e. no timeout)
+- Apply a timeout to the internal `whoami` command so a hung connection can no longer stall a deployment indefinitely
 
 
 ## v1.12.0 - 2026-07-11

--- a/inmanta_plugins/podman/resources/abc.py
+++ b/inmanta_plugins/podman/resources/abc.py
@@ -62,7 +62,7 @@ class HandlerABC(inmanta_plugins.mitogen.abc.Handler[ABC]):
         if hasattr(self.proxy, "_whoami"):
             return getattr(self.proxy, "_whoami")
 
-        stdout, stderr, ret = self.proxy.run("whoami")
+        stdout, stderr, ret = self.proxy.run("whoami", timeout=5)
         if ret == 0:
             setattr(self.proxy, "_whoami", stdout)
             return stdout

--- a/inmanta_plugins/podman/resources/image.py
+++ b/inmanta_plugins/podman/resources/image.py
@@ -133,9 +133,11 @@ class ImageFromSourceResource(ImageResource):
     fields = (
         "options",
         "context",
+        "build_timeout",
     )
     options: list[str]
     context: str | None
+    build_timeout: int | None
 
     @classmethod
     def get_options(
@@ -206,7 +208,7 @@ class ImageFromSourceHandler(ImageHandler[ImageFromSourceResource]):
             ctx,
             resource,
             command=cmd,
-            timeout=None,
+            timeout=resource.build_timeout,
         )
 
         # If the command failed, something went wrong

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -322,12 +322,15 @@ entity ImageFromSource extends Image:
     :attr squash_all: Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
     :attr pull: Pull image policy. (always, true, missing, never, false, newer)
     :attr context: The build context directory can be specified as the http(s) URL of an archive, git repository or Containerfile.
+    :attr build_timeout: The maximum duration, in seconds, that the build command
+        is allowed to take before it is aborted.  When null, no timeout is applied.
     """
     bool? squash = null
     bool? squash_all = null
     string? pull = null
     string? context = null
     string? file = null
+    int? build_timeout = null
 end
 
 

--- a/tests/test_image_from_source.py
+++ b/tests/test_image_from_source.py
@@ -51,6 +51,50 @@ def test_model(project: Project, purged: bool = False) -> None:
     project.compile(model, no_dedent=False)
 
 
+def test_build_timeout(project: Project) -> None:
+    # Build an image from a context that can not be reached, with a very
+    # short timeout.  The build command hangs trying to fetch the context,
+    # so the timeout aborts it and the deployment must fail explicitly.
+    model = """
+        import podman
+        import std
+        import mitogen
+
+
+        host = std::Host(
+            name="localhost",
+            remote_agent=true,
+            ip="127.0.0.1",
+            os=std::linux,
+            via=mitogen::Local(),
+        )
+
+        podman::ImageFromSource(
+            host=host,
+            name="inmanta/does-not-exist:latest",
+            # RFC 5737 TEST-NET-1 address, guaranteed not to be routable, so the
+            # build hangs fetching the context until our timeout kicks in.
+            context="https://192.0.2.1/inmanta/does-not-exist.git",
+            build_timeout=1,
+        )
+    """
+
+    project.compile(model, no_dedent=False)
+
+    resource = project.get_resource("podman::ImageFromSource")
+    assert resource is not None
+    assert resource.build_timeout == 1
+
+    result = project.deploy_resource_v2(
+        "podman::ImageFromSource",
+        expected_status=inmanta.const.ResourceState.failed,
+    )
+
+    # The failure must clearly point at the build command timing out after the
+    # configured duration.
+    result.assert_has_logline(r"podman.*build.*timed out after 1 seconds")
+
+
 def test_deploy(project: Project) -> None:
     # Build the alpine image
     test_model(project, purged=False)


### PR DESCRIPTION
## Summary

Closes a deployment-hang risk in the module: two remote I/O operations that could run without any timeout.

### `build_timeout` on `podman::ImageFromSource`
The image build command previously ran with `timeout=None`. This adds a configurable `build_timeout` attribute, mirroring the `pull_timeout` recently added to `podman::ImageFromRegistry` (#240). It defaults to `null`, preserving the previous no-timeout behaviour — a conservative, opt-in change.

### Bounded `whoami`
The internal `whoami` command — run before every owner-scoped operation in `run_command` — was executed with no timeout. A hung connection there would stall a deployment indefinitely, *before* any per-command timeout (e.g. `inspect`, `pull`) could apply. It is now bounded to 5 seconds, matching the other metadata commands.

## Tests
- New `test_build_timeout` (mirrors `test_pull_timeout`): points the build context at an unroutable RFC 5737 TEST-NET-1 address with `build_timeout=1` and asserts the deploy fails with `podman ... build ... timed out after 1 seconds`.
- `test_build_timeout` and `test_pull_timeout` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
